### PR TITLE
Implement basic auth screens and backend endpoints

### DIFF
--- a/backend/StudyEnglishMobileAppAPIs/StudyEnglishMobileAppAPIs/Controllers/UserController.cs
+++ b/backend/StudyEnglishMobileAppAPIs/StudyEnglishMobileAppAPIs/Controllers/UserController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using StudyEnglishMobileAppAPIs.Models;
+
+namespace StudyEnglishMobileAppAPIs.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class UserController : ControllerBase
+    {
+        private readonly StudyEnglishMobileAppContext _context;
+
+        public UserController(StudyEnglishMobileAppContext context)
+        {
+            _context = context;
+        }
+
+        [HttpPost("register")]
+        public async Task<ActionResult<User>> Register(User user)
+        {
+            _context.Users.Add(user);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetUser), new { id = user.Id }, user);
+        }
+
+        [HttpPost("login")]
+        public async Task<ActionResult<User>> Login(LoginRequest request)
+        {
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.Username == request.Username && u.Password == request.Password);
+            if (user == null)
+            {
+                return Unauthorized();
+            }
+            return user;
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<User>> GetUser(int id)
+        {
+            var user = await _context.Users.FindAsync(id);
+            if (user == null)
+            {
+                return NotFound();
+            }
+            return user;
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutUser(int id, User user)
+        {
+            if (id != user.Id)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(user).State = EntityState.Modified;
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!_context.Users.Any(e => e.Id == id))
+                {
+                    return NotFound();
+                }
+                throw;
+            }
+            return NoContent();
+        }
+    }
+}

--- a/backend/StudyEnglishMobileAppAPIs/StudyEnglishMobileAppAPIs/Models/LoginRequest.cs
+++ b/backend/StudyEnglishMobileAppAPIs/StudyEnglishMobileAppAPIs/Models/LoginRequest.cs
@@ -1,0 +1,8 @@
+namespace StudyEnglishMobileAppAPIs.Models
+{
+    public class LoginRequest
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/frontend/app/(tabs)/(profile)/index.tsx
+++ b/frontend/app/(tabs)/(profile)/index.tsx
@@ -1,22 +1,39 @@
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, View } from "react-native";
+import { Button } from "react-native-paper";
+import CustomText from "@/components/CustomText";
+import { useAuth } from "@/context/AuthContext";
+import { Link } from "expo-router";
 
 export default function ProfileScreen() {
+  const { user, logout } = useAuth();
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Welcome to the Profile Screen!</Text>
+      {user ? (
+        <>
+          <CustomText style={styles.title}>Hello {user.username}</CustomText>
+          <CustomText>Email: {user.email}</CustomText>
+          <Link href="/edit-profile" asChild>
+            <Button mode="contained" style={styles.button}>Edit Profile</Button>
+          </Link>
+          <Button mode="outlined" onPress={logout} style={styles.button}>
+            Logout
+          </Button>
+        </>
+      ) : (
+        <>
+          <CustomText style={styles.title}>Not logged in</CustomText>
+          <Link href="/login" asChild>
+            <Button mode="contained" style={styles.button}>Login</Button>
+          </Link>
+        </>
+      )}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 20,
-  },
-  title: {
-    fontSize: 22,
-    marginBottom: 20,
-  },
+  container: { flex: 1, justifyContent: "center", alignItems: "center", padding: 20 },
+  title: { fontSize: 22, marginBottom: 20 },
+  button: { marginTop: 16 },
 });

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -6,6 +6,7 @@ import {
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useColorScheme } from "@/hooks/useColorScheme";
+import { AuthProvider } from "@/context/AuthContext";
 
 import { useFonts, Baloo2_600SemiBold } from "@expo-google-fonts/baloo-2";
 import {
@@ -36,13 +37,15 @@ export default function RootLayout() {
 
   return (
     <PaperProvider theme={paperTheme}>
-      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" options={{ headerShown: false }} />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" options={{ headerShown: false }} />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </AuthProvider>
     </PaperProvider>
   );
 }

--- a/frontend/app/edit-profile.tsx
+++ b/frontend/app/edit-profile.tsx
@@ -1,0 +1,37 @@
+import { View, StyleSheet } from "react-native";
+import { TextInput, Button } from "react-native-paper";
+import { useState } from "react";
+import { useRouter } from "expo-router";
+import { useAuth } from "@/context/AuthContext";
+import { ThemedText } from "@/components/ThemedText";
+
+export default function EditProfileScreen() {
+  const { user, updateProfile } = useAuth();
+  const router = useRouter();
+  const [username, setUsername] = useState(user?.username ?? "");
+  const [email, setEmail] = useState(user?.email ?? "");
+
+  return (
+    <View style={styles.container}>
+      <ThemedText type="title">Edit Profile</ThemedText>
+      <TextInput label="Username" value={username} onChangeText={setUsername} style={styles.input} />
+      <TextInput label="Email" value={email} onChangeText={setEmail} style={styles.input} />
+      <Button
+        mode="contained"
+        onPress={async () => {
+          await updateProfile({ id: user!.id, username, email });
+          router.back();
+        }}
+        style={styles.button}
+      >
+        Save
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: "center", padding: 20 },
+  input: { marginTop: 16 },
+  button: { marginTop: 16 },
+});

--- a/frontend/app/login.tsx
+++ b/frontend/app/login.tsx
@@ -1,0 +1,32 @@
+import { View, StyleSheet } from "react-native";
+import { TextInput, Button } from "react-native-paper";
+import { useState } from "react";
+import { Link } from "expo-router";
+import { useAuth } from "@/context/AuthContext";
+import { ThemedText } from "@/components/ThemedText";
+
+export default function LoginScreen() {
+  const { login } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  return (
+    <View style={styles.container}>
+      <ThemedText type="title">Login</ThemedText>
+      <TextInput label="Username" value={username} onChangeText={setUsername} style={styles.input} />
+      <TextInput label="Password" value={password} onChangeText={setPassword} secureTextEntry style={styles.input} />
+      <Button mode="contained" onPress={() => login(username, password)} style={styles.button}>
+        Login
+      </Button>
+      <Link href="/register" asChild>
+        <Button style={styles.button}>Register</Button>
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: "center", padding: 20 },
+  input: { marginTop: 16 },
+  button: { marginTop: 16 },
+});

--- a/frontend/app/register.tsx
+++ b/frontend/app/register.tsx
@@ -1,0 +1,30 @@
+import { View, StyleSheet } from "react-native";
+import { TextInput, Button } from "react-native-paper";
+import { useState } from "react";
+import { useAuth } from "@/context/AuthContext";
+import { ThemedText } from "@/components/ThemedText";
+
+export default function RegisterScreen() {
+  const { register } = useAuth();
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  return (
+    <View style={styles.container}>
+      <ThemedText type="title">Register</ThemedText>
+      <TextInput label="Username" value={username} onChangeText={setUsername} style={styles.input} />
+      <TextInput label="Email" value={email} onChangeText={setEmail} style={styles.input} />
+      <TextInput label="Password" value={password} onChangeText={setPassword} secureTextEntry style={styles.input} />
+      <Button mode="contained" onPress={() => register(username, email, password)} style={styles.button}>
+        Sign Up
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: "center", padding: 20 },
+  input: { marginTop: 16 },
+  button: { marginTop: 16 },
+});

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -1,0 +1,97 @@
+import React, { createContext, useContext, useState } from "react";
+import { Alert } from "react-native";
+
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  role?: string;
+  currentLevel?: number;
+}
+
+interface AuthContextType {
+  user: User | null;
+  login: (username: string, password: string) => Promise<void>;
+  register: (username: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+  updateProfile: (user: User) => Promise<void>;
+}
+
+const API_URL = "http://localhost:5130/api";
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  const login = async (username: string, password: string) => {
+    try {
+      const res = await fetch(`${API_URL}/User/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      if (res.ok) {
+        const json = await res.json();
+        setUser(json);
+      } else {
+        Alert.alert("Login failed");
+      }
+    } catch (err) {
+      console.error(err);
+      Alert.alert("Login error");
+    }
+  };
+
+  const register = async (username: string, email: string, password: string) => {
+    try {
+      const res = await fetch(`${API_URL}/User/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, email, password }),
+      });
+      if (res.ok) {
+        const json = await res.json();
+        setUser(json);
+      } else {
+        Alert.alert("Registration failed");
+      }
+    } catch (err) {
+      console.error(err);
+      Alert.alert("Registration error");
+    }
+  };
+
+  const updateProfile = async (info: User) => {
+    if (!user) return;
+    try {
+      const res = await fetch(`${API_URL}/User/${user.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...user, ...info }),
+      });
+      if (res.ok) {
+        setUser({ ...user, ...info });
+      } else {
+        Alert.alert("Update failed");
+      }
+    } catch (err) {
+      console.error(err);
+      Alert.alert("Update error");
+    }
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, register, logout, updateProfile }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add simple `AuthProvider` context and wrap root layout
- create login, register and edit profile screens
- extend profile screen with login/logout buttons
- implement `UserController` with register/login/update APIs

## Testing
- `npm run lint` *(fails: expo not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684686f7f8b88329933a53507f1ed84a