### PR TITLE
Implement auth navigation flow

### DIFF
--- a/frontend/app/login.tsx
+++ b/frontend/app/login.tsx
@@ -1,12 +1,13 @@
 import { View, StyleSheet } from "react-native";
 import { TextInput, Button } from "react-native-paper";
 import { useState } from "react";
-import { Link } from "expo-router";
+import { Link, useRouter } from "expo-router";
 import { useAuth } from "@/context/AuthContext";
 import { ThemedText } from "@/components/ThemedText";
 
 export default function LoginScreen() {
   const { login } = useAuth();
+  const router = useRouter();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 
@@ -15,7 +16,16 @@ export default function LoginScreen() {
       <ThemedText type="title">Login</ThemedText>
       <TextInput label="Username" value={username} onChangeText={setUsername} style={styles.input} />
       <TextInput label="Password" value={password} onChangeText={setPassword} secureTextEntry style={styles.input} />
-      <Button mode="contained" onPress={() => login(username, password)} style={styles.button}>
+      <Button
+        mode="contained"
+        onPress={async () => {
+          const success = await login(username, password);
+          if (success) {
+            router.replace("/profile");
+          }
+        }}
+        style={styles.button}
+      >
         Login
       </Button>
       <Link href="/register" asChild>

--- a/frontend/app/register.tsx
+++ b/frontend/app/register.tsx
@@ -2,10 +2,12 @@ import { View, StyleSheet } from "react-native";
 import { TextInput, Button } from "react-native-paper";
 import { useState } from "react";
 import { useAuth } from "@/context/AuthContext";
+import { useRouter } from "expo-router";
 import { ThemedText } from "@/components/ThemedText";
 
 export default function RegisterScreen() {
   const { register } = useAuth();
+  const router = useRouter();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -16,7 +18,16 @@ export default function RegisterScreen() {
       <TextInput label="Username" value={username} onChangeText={setUsername} style={styles.input} />
       <TextInput label="Email" value={email} onChangeText={setEmail} style={styles.input} />
       <TextInput label="Password" value={password} onChangeText={setPassword} secureTextEntry style={styles.input} />
-      <Button mode="contained" onPress={() => register(username, email, password)} style={styles.button}>
+      <Button
+        mode="contained"
+        onPress={async () => {
+          const success = await register(username, email, password);
+          if (success) {
+            router.replace("/login");
+          }
+        }}
+        style={styles.button}
+      >
         Sign Up
       </Button>
     </View>

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -11,8 +11,22 @@ export interface User {
 
 interface AuthContextType {
   user: User | null;
-  login: (username: string, password: string) => Promise<void>;
-  register: (username: string, email: string, password: string) => Promise<void>;
+  /**
+   * Attempts to log a user in.
+   *
+   * @returns true when authentication succeeds
+   */
+  login: (username: string, password: string) => Promise<boolean>;
+  /**
+   * Attempts to register a new user.
+   *
+   * @returns true when registration succeeds
+   */
+  register: (
+    username: string,
+    email: string,
+    password: string
+  ) => Promise<boolean>;
   logout: () => void;
   updateProfile: (user: User) => Promise<void>;
 }
@@ -24,7 +38,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
 
-  const login = async (username: string, password: string) => {
+  const login = async (username: string, password: string): Promise<boolean> => {
     try {
       const res = await fetch(`${API_URL}/User/login`, {
         method: "POST",
@@ -34,16 +48,23 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (res.ok) {
         const json = await res.json();
         setUser(json);
+        return true;
       } else {
         Alert.alert("Login failed");
+        return false;
       }
     } catch (err) {
       console.error(err);
       Alert.alert("Login error");
+      return false;
     }
   };
 
-  const register = async (username: string, email: string, password: string) => {
+  const register = async (
+    username: string,
+    email: string,
+    password: string
+  ): Promise<boolean> => {
     try {
       const res = await fetch(`${API_URL}/User/register`, {
         method: "POST",
@@ -53,12 +74,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (res.ok) {
         const json = await res.json();
         setUser(json);
+        return true;
       } else {
         Alert.alert("Registration failed");
+        return false;
       }
     } catch (err) {
       console.error(err);
       Alert.alert("Registration error");
+      return false;
     }
   };
 


### PR DESCRIPTION
## Summary
- return success flag from login and register API helpers
- navigate to profile screen after successful login
- navigate to login screen after successful registration

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684695030d848329822876b21aebf379